### PR TITLE
Fix import of Py3.8 typing.final #4

### DIFF
--- a/lib/dcso/glosom/constants.py
+++ b/lib/dcso/glosom/constants.py
@@ -1,7 +1,5 @@
 # Copyright (c) 2020, DCSO GmbH
 
-from typing import Final
-
 GROUP_SYSTEM = 0x01
 """Constant defining GLOSOM System message group (0x01)"""
 


### PR DESCRIPTION
Previously, a Python 3.8 feature was imported in code that needs to
be compatible with Python 3.7.

We remove the rogue import (was not used), so that Python 3.7 is now
correctly supported.