### PR TITLE
Fix raising errors not having GLOSOM code

### DIFF
--- a/lib/dcso/glosom/glosom.py
+++ b/lib/dcso/glosom/glosom.py
@@ -120,6 +120,9 @@ class GlosomException(Exception):
 
     def __str__(self) -> str:
         if self.glosom.message_id == 0:
+            # try with non-GLOSOM
+            if self.glosom.message != "":
+                return self.glosom.message
             return "invalid message"
         else:
             return "{msg} ({code:X})".format(msg=self.glosom.message, code=self.glosom.code)


### PR DESCRIPTION
Previously, when the GraphQL API returned errors not having a GLOSOM
code, the exception would simply say "invalid message".

We now try to recover from errors not having a code, and if the message
is not empty, return this message instead.

Closes #6.