### PR TITLE
Fix documentation installing from PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ Installation
 This section explains how to install the DCSO Portal Python SDK. You can get
 a copy and source on [GitHub](https://github.com/dcso/dcso-portal-python-sdk).
 
+### From Python Package Index (PyPI)
+
+    $ pip install -U dcso-portal-python-sdk
+
+
 ### Using Source
 
 Installation is done using `setup.py`:

--- a/docs/dcso/glosom/constants.html
+++ b/docs/dcso/glosom/constants.html
@@ -143,7 +143,7 @@ TYPE_DEBUG = 0x90
 <p>Copyright (c) 2020, <a href="https://dcso.de">DCSO Deutsche Cyber-Sicherheitsorganisation GmbH</a></p>
 </div>
 <div>
-<p><strong>v0.1.0-beta1</strong></p>
+<p><strong>v1.0.0-beta2</strong></p>
 </div>
 </div>
 </footer>

--- a/docs/dcso/glosom/glosom.html
+++ b/docs/dcso/glosom/glosom.html
@@ -446,7 +446,7 @@ the GLOSOM as error. The extensions contains the code as integer.</p>
 <p>Copyright (c) 2020, <a href="https://dcso.de">DCSO Deutsche Cyber-Sicherheitsorganisation GmbH</a></p>
 </div>
 <div>
-<p><strong>v0.1.0-beta1</strong></p>
+<p><strong>v1.0.0-beta2</strong></p>
 </div>
 </div>
 </footer>

--- a/docs/dcso/glosom/index.html
+++ b/docs/dcso/glosom/index.html
@@ -91,7 +91,7 @@ APP_CODE = 0x00</code></pre>
 <p>Copyright (c) 2020, <a href="https://dcso.de">DCSO Deutsche Cyber-Sicherheitsorganisation GmbH</a></p>
 </div>
 <div>
-<p><strong>v0.1.0-beta1</strong></p>
+<p><strong>v1.0.0-beta2</strong></p>
 </div>
 </div>
 </footer>

--- a/docs/dcso/index.html
+++ b/docs/dcso/index.html
@@ -71,7 +71,7 @@ which need to interact with the DCSO Portal …</p></div>
 <p>Copyright (c) 2020, <a href="https://dcso.de">DCSO Deutsche Cyber-Sicherheitsorganisation GmbH</a></p>
 </div>
 <div>
-<p><strong>v0.1.0-beta1</strong></p>
+<p><strong>v1.0.0-beta2</strong></p>
 </div>
 </div>
 </footer>

--- a/docs/dcso/portal/abstracts.html
+++ b/docs/dcso/portal/abstracts.html
@@ -161,7 +161,7 @@ def token(self) -&gt; str:
 <h3>Methods</h3>
 <dl>
 <dt id="dcso.portal.abstracts.APIAbstract.execute_graphql"><code class="name flex">
-<span>def <span class="ident">execute_graphql</span></span>(<span>self, query: str, variables: Union[dict, NoneType] = None, fragments: Union[List[str], NoneType] = None) ‑> <function namedtuple at 0x7fa1a4c01830></span>
+<span>def <span class="ident">execute_graphql</span></span>(<span>self, query: str, variables: Union[dict, NoneType] = None, fragments: Union[List[str], NoneType] = None) ‑> <function namedtuple at 0x7fc9a5b1e830></span>
 </code></dt>
 <dd>
 <div class="desc"></div>
@@ -245,7 +245,7 @@ def execute_graphql(self, query: str,
 <p>Copyright (c) 2020, <a href="https://dcso.de">DCSO Deutsche Cyber-Sicherheitsorganisation GmbH</a></p>
 </div>
 <div>
-<p><strong>v0.1.0-beta1</strong></p>
+<p><strong>v1.0.0-beta2</strong></p>
 </div>
 </div>
 </footer>

--- a/docs/dcso/portal/api.html
+++ b/docs/dcso/portal/api.html
@@ -401,7 +401,7 @@ def token(self) -&gt; str:
 </details>
 </dd>
 <dt id="dcso.portal.api.APIClient.execute_graphql"><code class="name flex">
-<span>def <span class="ident">execute_graphql</span></span>(<span>self, query: str, variables: Union[dict, NoneType] = None, fragments: Union[List[str], NoneType] = None) ‑> <function namedtuple at 0x7fa1a4c01830></span>
+<span>def <span class="ident">execute_graphql</span></span>(<span>self, query: str, variables: Union[dict, NoneType] = None, fragments: Union[List[str], NoneType] = None) ‑> <function namedtuple at 0x7fc9a5b1e830></span>
 </code></dt>
 <dd>
 <div class="desc"><p>Executes the GraphQL query and returns response as namedtuple. This
@@ -596,7 +596,7 @@ the <code>PortalAPIRequest</code> exception is raised.</p></div>
 <p>Copyright (c) 2020, <a href="https://dcso.de">DCSO Deutsche Cyber-Sicherheitsorganisation GmbH</a></p>
 </div>
 <div>
-<p><strong>v0.1.0-beta1</strong></p>
+<p><strong>v1.0.0-beta2</strong></p>
 </div>
 </div>
 </footer>

--- a/docs/dcso/portal/auth/auth.html
+++ b/docs/dcso/portal/auth/auth.html
@@ -721,7 +721,7 @@ the <code>PortalAPIRequest</code> exception is raised.</p></div>
 <p>Copyright (c) 2020, <a href="https://dcso.de">DCSO Deutsche Cyber-Sicherheitsorganisation GmbH</a></p>
 </div>
 <div>
-<p><strong>v0.1.0-beta1</strong></p>
+<p><strong>v1.0.0-beta2</strong></p>
 </div>
 </div>
 </footer>

--- a/docs/dcso/portal/auth/index.html
+++ b/docs/dcso/portal/auth/index.html
@@ -98,7 +98,7 @@ from .auth import Auth, Authentication</code></pre>
 <p>Copyright (c) 2020, <a href="https://dcso.de">DCSO Deutsche Cyber-Sicherheitsorganisation GmbH</a></p>
 </div>
 <div>
-<p><strong>v0.1.0-beta1</strong></p>
+<p><strong>v1.0.0-beta2</strong></p>
 </div>
 </div>
 </footer>

--- a/docs/dcso/portal/auth/rbac.html
+++ b/docs/dcso/portal/auth/rbac.html
@@ -480,7 +480,7 @@ be queried for.</p>
 <p>Copyright (c) 2020, <a href="https://dcso.de">DCSO Deutsche Cyber-Sicherheitsorganisation GmbH</a></p>
 </div>
 <div>
-<p><strong>v0.1.0-beta1</strong></p>
+<p><strong>v1.0.0-beta2</strong></p>
 </div>
 </div>
 </footer>

--- a/docs/dcso/portal/auth/token.html
+++ b/docs/dcso/portal/auth/token.html
@@ -288,7 +288,7 @@ def is_temporary(self) -&gt; bool:
 <p>Copyright (c) 2020, <a href="https://dcso.de">DCSO Deutsche Cyber-Sicherheitsorganisation GmbH</a></p>
 </div>
 <div>
-<p><strong>v0.1.0-beta1</strong></p>
+<p><strong>v1.0.0-beta2</strong></p>
 </div>
 </div>
 </footer>

--- a/docs/dcso/portal/exceptions.html
+++ b/docs/dcso/portal/exceptions.html
@@ -260,7 +260,7 @@ class PortalAPIResponse(PortalException):
 <p>Copyright (c) 2020, <a href="https://dcso.de">DCSO Deutsche Cyber-Sicherheitsorganisation GmbH</a></p>
 </div>
 <div>
-<p><strong>v0.1.0-beta1</strong></p>
+<p><strong>v1.0.0-beta2</strong></p>
 </div>
 </div>
 </footer>

--- a/docs/dcso/portal/index.html
+++ b/docs/dcso/portal/index.html
@@ -29,7 +29,7 @@ which need to interact with the DCSO Portal …" />
 which need to interact with the DCSO Portal.</p>
 <h2 id="installation">Installation</h2>
 <p>To install the latest DCSO Portal SDK using pip:</p>
-<pre><code>$ pip install dcso-portal-sdk
+<pre><code>$ pip install dcso-portal-python-sdk
 </code></pre>
 <p>We advise to use a Virtual Environment when testing/developing.</p>
 <p>Alternatively, you can can download or clone the DCSO Portal SDK from
@@ -211,7 +211,7 @@ the DCSO Portal API.</p></div>
 <p>Copyright (c) 2020, <a href="https://dcso.de">DCSO Deutsche Cyber-Sicherheitsorganisation GmbH</a></p>
 </div>
 <div>
-<p><strong>v0.1.0-beta1</strong></p>
+<p><strong>v1.0.0-beta2</strong></p>
 </div>
 </div>
 </footer>

--- a/docs/dcso/portal/util/graphql.html
+++ b/docs/dcso/portal/util/graphql.html
@@ -214,7 +214,7 @@ def graphql_data_to_namedtuple(mapping: dict, name: str = &#39;data&#39;) -&gt; 
 <h2 class="section-title" id="header-functions">Functions</h2>
 <dl>
 <dt id="dcso.portal.util.graphql.graphql_data_to_namedtuple"><code class="name flex">
-<span>def <span class="ident">graphql_data_to_namedtuple</span></span>(<span>mapping: dict, name: str = 'data') ‑> <function namedtuple at 0x7fa1a4c01830></span>
+<span>def <span class="ident">graphql_data_to_namedtuple</span></span>(<span>mapping: dict, name: str = 'data') ‑> <function namedtuple at 0x7fc9a5b1e830></span>
 </code></dt>
 <dd>
 <div class="desc"><p>Transforms GraphQL response data and returns it as a namedtuple.</p>
@@ -629,7 +629,7 @@ implement default like this::</p>
 <h3>Methods</h3>
 <dl>
 <dt id="dcso.portal.util.graphql.GraphQLRequest.execute"><code class="name flex">
-<span>def <span class="ident">execute</span></span>(<span>self) ‑> <function namedtuple at 0x7fa1a4c01830></span>
+<span>def <span class="ident">execute</span></span>(<span>self) ‑> <function namedtuple at 0x7fc9a5b1e830></span>
 </code></dt>
 <dd>
 <div class="desc"><p>Executes the GraphQL request returning response as a namedtuple.</p>
@@ -835,7 +835,7 @@ to use.</p>
 <p>Copyright (c) 2020, <a href="https://dcso.de">DCSO Deutsche Cyber-Sicherheitsorganisation GmbH</a></p>
 </div>
 <div>
-<p><strong>v0.1.0-beta1</strong></p>
+<p><strong>v1.0.0-beta2</strong></p>
 </div>
 </div>
 </footer>

--- a/docs/dcso/portal/util/index.html
+++ b/docs/dcso/portal/util/index.html
@@ -97,7 +97,7 @@ __pdoc__ = {
 <p>Copyright (c) 2020, <a href="https://dcso.de">DCSO Deutsche Cyber-Sicherheitsorganisation GmbH</a></p>
 </div>
 <div>
-<p><strong>v0.1.0-beta1</strong></p>
+<p><strong>v1.0.0-beta2</strong></p>
 </div>
 </div>
 </footer>

--- a/docs/dcso/portal/util/networking.html
+++ b/docs/dcso/portal/util/networking.html
@@ -177,7 +177,7 @@ validated URL.</p>
 <p>Copyright (c) 2020, <a href="https://dcso.de">DCSO Deutsche Cyber-Sicherheitsorganisation GmbH</a></p>
 </div>
 <div>
-<p><strong>v0.1.0-beta1</strong></p>
+<p><strong>v1.0.0-beta2</strong></p>
 </div>
 </div>
 </footer>

--- a/docs/dcso/portal/util/temporal.html
+++ b/docs/dcso/portal/util/temporal.html
@@ -404,7 +404,7 @@ If dt is naive, timezone is first set, assuming it to be UTC.</p></div>
 <p>Copyright (c) 2020, <a href="https://dcso.de">DCSO Deutsche Cyber-Sicherheitsorganisation GmbH</a></p>
 </div>
 <div>
-<p><strong>v0.1.0-beta1</strong></p>
+<p><strong>v1.0.0-beta2</strong></p>
 </div>
 </div>
 </footer>

--- a/lib/dcso/portal/README.md
+++ b/lib/dcso/portal/README.md
@@ -7,7 +7,7 @@ Installation
 
 To install the latest DCSO Portal SDK using pip:
 
-    $ pip install dcso-portal-sdk
+    $ pip install dcso-portal-python-sdk
 
 We advise to use a Virtual Environment when testing/developing.
 

--- a/lib/dcso/portal/_version.py
+++ b/lib/dcso/portal/_version.py
@@ -1,3 +1,3 @@
 # Copyright (c) 2021, DCSO GmbH
 
-__version__ = "1.0.0-beta1"
+__version__ = "1.0.0-beta2"

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, DCSO GmbH
+# Copyright (c) 2020, 2021, DCSO GmbH
 
 import os
 import sys
@@ -11,24 +11,29 @@ sys.path.insert(0, os.path.join(curr_wd, 'lib'))
 
 from lib.dcso.portal._version import __version__  # nopep8 allowing import here
 
+with open(os.path.join(os.path.abspath(curr_wd), 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
 setup(name='dcso_portal_python_sdk',
       version=__version__,
       description="DCSO Portal SDK",
+      long_description=long_description,
+      long_description_content_type='text/markdown',
       author='DCSO GmbH',
       author_email='portal-support@dcso.de',
-      url="https://dcso.de",
+      url="https://dcso.github.io/dcso-portal-python-sdk/dcso/portal/",
       package_dir={'': 'lib'},
       packages=find_namespace_packages(where='lib'),
       license='MIT License',
       license_files=['LICENSE.txt'],
       platforms=['Any'],
       classifiers=[
-            "Programming Language :: Python :: 3 :: Only",
-            "Programming Language :: Python :: 3.7",
-            "Operating System :: OS Independent",
-            "Development Status :: 3 - Alpha",
-            "License :: OSI Approved :: MIT License",
-            "Topic :: Software Development",
-            "Topic :: Software Development :: Version Control :: Git",
+          "Programming Language :: Python :: 3 :: Only",
+          "Programming Language :: Python :: 3.7",
+          "Operating System :: OS Independent",
+          "Development Status :: 4 - Beta",
+          "License :: OSI Approved :: MIT License",
+          "Topic :: Software Development",
+          "Topic :: Software Development :: Version Control :: Git",
       ],
       )


### PR DESCRIPTION
We fix the installation documentation so that the correct name is
used with the `pip` command.

We also make sure that the description is showing when viewing the
entry in the Python Package Index (PyPI).